### PR TITLE
MNT: drop unused type checkers settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,10 +141,3 @@ convention = "numpy"
 quote-style = "double"
 indent-style = "space"
 line-ending = "auto"
-
-[tool.ty.environment]
-python-version = "3.12"
-
-[tool.pyrefly]
-python-version = "3.12"
-


### PR DESCRIPTION
Both ty and pyrefly already use `[project.requires-python]` by default, so these settings are redundant.