### PR TITLE
Fix Read the Docs build (uv) and broken pip dev-install

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,27 +9,23 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3.13"
-    # You can also specify other tool versions:
-    # nodejs: "20"
-    # rust: "1.70"
-    # golang: "1.20"
+  jobs:
+    # uv is not pre-installed on Read the Docs, so bootstrap it via asdf.
+    create_environment:
+      - asdf plugin add uv
+      - asdf install uv latest
+      - asdf global uv latest
+    # Install the project plus the Sphinx toolchain. The docs dependencies live
+    # in the `docs` dependency-group and the theme (pydata-sphinx-theme) in the
+    # default `dev` group -- neither of which a plain pip requirements file can
+    # resolve. This mirrors the GitHub "Build Documentation" workflow exactly.
+    install:
+      - uv sync --group docs --extra gui
+    # Build the HTML into the directory Read the Docs publishes from.
+    build:
+      html:
+        - uv run --no-sync sphinx-build -b html Docs/source $READTHEDOCS_OUTPUT/html
 
-# Build documentation in the "docs/" directory with Sphinx
+# Build documentation with Sphinx
 sphinx:
   configuration: Docs/source/conf.py
-  # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
-  # builder: "dirhtml"
-  # Fail on all warnings to avoid broken references
-  # fail_on_warning: true
-
-# Optionally build your docs in additional formats such as PDF and ePub
-# formats:
-#   - pdf
-#   - epub
-
-# Optional but recommended, declare the Python requirements required
-# to build your documentation
-# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-python:
-  install:
-    - requirements: requirements_dev.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,15 +77,18 @@ pixi run -e all pre-commit run --all-files
 pixi run -e all pytest -v ./Tests
 ```
 
-### Option C: `pip` fallback (not lockfile-based)
+### Option C: `pip` (no lockfile)
 
-If you prefer a classic setup:
+uv (Option A) is the recommended setup, but if you prefer plain `pip` you can
+install the project together with its dependency groups (requires `pip >= 25.1`,
+which understands PEP 735 dependency groups):
 
 ```bash
-pip install -r requirements_dev.txt
+pip install -e ".[gui]" --group dev --group test --group docs
 ```
 
-`requirements_dev.txt` installs the project in editable mode with development extras.
+This installs PyPLUTO in editable mode with the development, test and
+documentation tooling. Unlike Options A and B it is not lockfile-based.
 
 ## Pre-commit and Quality Checks
 

--- a/Docs/source/contributing.rst
+++ b/Docs/source/contributing.rst
@@ -100,14 +100,18 @@ Run tools in that environment:
    $ pixi run -e all pre-commit run --all-files
    $ pixi run -e all pytest -v ./Tests
 
-**Option C: pip fallback (not lockfile-based)**
+**Option C: pip (no lockfile)**
+
+uv (Option A) is the recommended setup, but if you prefer plain ``pip`` you can
+install the project together with its dependency groups (requires ``pip >= 25.1``,
+which understands PEP 735 dependency groups):
 
 .. code-block:: console
 
-   $ pip install -r requirements_dev.txt
+   $ pip install -e ".[gui]" --group dev --group test --group docs
 
-``requirements_dev.txt`` installs the project in editable mode with development
-extras.
+This installs PyPLUTO in editable mode with the development, test and
+documentation tooling. Unlike Options A and B it is not lockfile-based.
 
 |
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,1 +1,0 @@
--e .[gui,local-dev]


### PR DESCRIPTION
## Why

The **docs badge was red**: Read the Docs builds were failing. RTD installed only `-e .[gui,local-dev]` via `requirements_dev.txt`, which pulls neither the `docs` dependency-group (`sphinx`, `sphinx-automodapi`, `numpydoc`) nor the `pydata-sphinx-theme` in the default `dev` group — PEP 735 dependency-groups are invisible to a plain pip requirements file. So Sphinx never installed and the build died. (GitHub's own docs workflow stayed green because it uses `uv sync`.)

Separately, `local-dev` is a **pixi environment**, not a project extra, so the documented `pip install -r requirements_dev.txt` contributor command also always errored.

## Changes

- **`.readthedocs.yaml`**: bootstrap uv and build with `uv sync --group docs --extra gui` + `sphinx-build`, mirroring the GitHub "Build Documentation" workflow so the two can't drift. Verified locally — build succeeds.
- **`CONTRIBUTING.md` / `Docs/source/contributing.rst`**: replace the broken pip "Option C" with `pip install -e ".[gui]" --group dev --group test --group docs` (pip ≥ 25.1, PEP 735). uv remains the recommended path.
- **Delete** the orphaned `requirements_dev.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)